### PR TITLE
Fix syntax error in copier module

### DIFF
--- a/copier.py
+++ b/copier.py
@@ -968,19 +968,19 @@ class TelegramCopier:
             # НОВАЯ АРХИТЕКТУРА: Батчевая обработка
             batch_number = 1
             
-                    # Получаем батчи сообщений и обрабатываем их по порядку
-        async for batch in self._get_message_batches(min_id):
-            if not batch:  # Пустой батч - конец
-                break
-            
-            self.logger.info(f"📦 Обрабатываем батч #{batch_number}: {len(batch)} сообщений")
-            
-            # НОВОЕ: Предварительно загружаем комментарии для батча (только один раз)
-            if not self.comments_cache_loaded:
-                await self.preload_all_comments_cache(batch)
-            
-            # Обрабатываем батч в хронологическом порядке
-            batch_stats = await self._process_message_batch(batch, progress_tracker)
+            # Получаем батчи сообщений и обрабатываем их по порядку
+            async for batch in self._get_message_batches(min_id):
+                if not batch:  # Пустой батч - конец
+                    break
+                
+                self.logger.info(f"📦 Обрабатываем батч #{batch_number}: {len(batch)} сообщений")
+                
+                # НОВОЕ: Предварительно загружаем комментарии для батча (только один раз)
+                if not self.comments_cache_loaded:
+                    await self.preload_all_comments_cache(batch)
+                
+                # Обрабатываем батч в хронологическом порядке
+                batch_stats = await self._process_message_batch(batch, progress_tracker)
                 
                 # Обновляем общую статистику
                 self.copied_messages += batch_stats['copied']


### PR DESCRIPTION
Fixes `SyntaxError` in `copier.py` by correcting indentation of `async for` loop.

The `async for` loop was incorrectly indented outside its `try` block, causing the application to fail at startup with a `SyntaxError: expected 'except' or 'finally' block`.

---
<a href="https://cursor.com/background-agent?bcId=bc-5a8cf55f-d2b6-4583-945e-57af4013cfaa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5a8cf55f-d2b6-4583-945e-57af4013cfaa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

